### PR TITLE
ethcore: Make account_db module public

### DIFF
--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -164,7 +164,7 @@ pub mod verification;
 mod cache_manager;
 mod blooms;
 mod pod_account;
-mod account_db;
+pub mod account_db;
 mod builtin;
 mod externalities;
 pub mod blockchain;


### PR DESCRIPTION
Same as in #13 but for `ekiden-web3` branch.