### PR TITLE
fetch_bytes: don't crash when data doesn't exist

### DIFF
--- a/ethcore/wasm/src/runtime.rs
+++ b/ethcore/wasm/src/runtime.rs
@@ -732,7 +732,7 @@ impl<'a> Runtime<'a> {
 	/// Signature: `fn fetch_bytes(key: *const u8, result: *mut u8)`
 	pub fn fetch_bytes(&mut self, args: RuntimeArgs) -> Result<()> {
 		let key = self.h256_at(args.nth_checked(0)?)?;
-		let bytes = self.ext.fetch_bytes(&key).unwrap();
+		let bytes = self.ext.fetch_bytes(&key).map_err(|_| Error::StorageReadError)?;
 		self.memory.set(args.nth_checked(1)?, &bytes)?;
 
 		Ok(())


### PR DESCRIPTION
Fixes https://github.com/oasislabs/runtime-ethereum/issues/341