### PR TITLE
Replace futures-timer with tokio-timer

### DIFF
--- a/util/fetch/Cargo.toml
+++ b/util/fetch/Cargo.toml
@@ -8,11 +8,11 @@ authors = ["Parity Technologies <admin@parity.io>"]
 
 [dependencies]
 futures = "0.1"
-futures-timer = "0.1"
 hyper = "0.11"
 hyper-rustls = "0.11"
 log = "0.4"
 tokio-core = "0.1"
+tokio-timer = "0.1"
 url = "1"
 bytes = "0.4"
 

--- a/util/fetch/src/lib.rs
+++ b/util/fetch/src/lib.rs
@@ -23,12 +23,12 @@ extern crate log;
 
 #[macro_use]
 extern crate futures;
-extern crate futures_timer;
 
 extern crate hyper;
 extern crate hyper_rustls;
 
 extern crate tokio_core;
+extern crate tokio_timer;
 extern crate url;
 extern crate bytes;
 


### PR DESCRIPTION
Trying to get code coverage working for the gateway: https://github.com/oasislabs/runtime-ethereum/pull/350

See https://github.com/paritytech/parity-ethereum/pull/9066/commits/5cd8a8929d68c39fe3d40082b47f5ed295af3d0b