### PR TITLE
ethcore: remove 'gateway' feature

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       - run:
           name: Build ethcore for gateway
           working_directory: ethcore
-          command: cargo build --features "gateway"
+          command: cargo build
 
       # Build other gateway dependencies
       - run:

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -95,7 +95,6 @@ test-heavy = []
 benches = []
 # Compile test helpers
 test-helpers = []
-gateway = []
 # Execute confidential transactions
 enable-confidential = []
 # Don't allow non-confidential transctions. Used for an exlusively confidential chain.

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -184,7 +184,6 @@ impl TransactOptions<trace::NoopTracer, trace::NoopVMTracer, NoopExtTracer> {
 }
 
 /// Transaction executor.
-#[cfg(feature = "gateway")]
 pub struct Executive<'a, B: 'a + StateBackend> {
 	state: &'a mut State<B>,
 	info: &'a EnvInfo,
@@ -193,31 +192,10 @@ pub struct Executive<'a, B: 'a + StateBackend> {
 	static_flag: bool,
 	storage: &'a Storage,
 }
-#[cfg(not(feature = "gateway"))]
-pub struct Executive<'a, B: 'a + StateBackend> {
-	state: &'a mut State<B>,
-	info: &'a EnvInfo,
-	machine: &'a Machine,
-	depth: usize,
-	static_flag: bool,
-	storage: &'a mut Storage,
-}
 
 impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 	/// Basic constructor.
-	#[cfg(feature = "gateway")]
 	pub fn new(state: &'a mut State<B>, info: &'a EnvInfo, machine: &'a Machine, storage: &'a Storage) -> Self {
-		Executive {
-			state: state,
-			info: info,
-			machine: machine,
-			depth: 0,
-			static_flag: false,
-			storage: storage,
-		}
-	}
-	#[cfg(not(feature = "gateway"))]
-	pub fn new(state: &'a mut State<B>, info: &'a EnvInfo, machine: &'a Machine, storage: &'a mut Storage) -> Self {
 		Executive {
 			state: state,
 			info: info,
@@ -229,19 +207,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 	}
 
 	/// Populates executive from parent properties. Increments executive depth.
-	#[cfg(feature = "gateway")]
 	pub fn from_parent(state: &'a mut State<B>, info: &'a EnvInfo, machine: &'a Machine, parent_depth: usize, static_flag: bool, storage: &'a Storage) -> Self {
-		Executive {
-			state: state,
-			info: info,
-			machine: machine,
-			depth: parent_depth + 1,
-			static_flag: static_flag,
-			storage: storage,
-		}
-	}
-	#[cfg(not(feature = "gateway"))]
-	pub fn from_parent(state: &'a mut State<B>, info: &'a EnvInfo, machine: &'a Machine, parent_depth: usize, static_flag: bool, storage: &'a mut Storage) -> Self {
 		Executive {
 			state: state,
 			info: info,

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -67,7 +67,6 @@ impl OriginInfo {
 }
 
 /// Implementation of evm Externalities.
-#[cfg(feature = "gateway")]
 pub struct Externalities<'a, T: 'a, V: 'a, X: 'a, B: 'a>
 	where T: Tracer, V:  VMTracer, X: ExtTracer, B: StateBackend
 {
@@ -86,31 +85,11 @@ pub struct Externalities<'a, T: 'a, V: 'a, X: 'a, B: 'a>
 	storage: &'a Storage,
 	encryption_key: Option<Vec<u8>>,
 }
-#[cfg(not(feature = "gateway"))]
-pub struct Externalities<'a, T: 'a, V: 'a, X: 'a, B: 'a>
-	where T: Tracer, V:  VMTracer, X: ExtTracer, B: StateBackend
-{
-	state: &'a mut State<B>,
-	env_info: &'a EnvInfo,
-	machine: &'a Machine,
-	depth: usize,
-	origin_info: OriginInfo,
-	substate: &'a mut Substate,
-	schedule: Schedule,
-	output: OutputPolicy<'a, 'a>,
-	tracer: &'a mut T,
-	vm_tracer: &'a mut V,
-	ext_tracer: &'a mut X,
-	static_flag: bool,
-	storage: &'a mut Storage,
-	encryption_key: Option<Vec<u8>>,
-}
 
 impl<'a, T: 'a, V: 'a, X: 'a, B: 'a> Externalities<'a, T, V, X, B>
 	where T: Tracer, V: VMTracer, X: ExtTracer, B: StateBackend
 {
 	/// Basic `Externalities` constructor.
-	#[cfg(feature = "gateway")]
 	pub fn new(state: &'a mut State<B>,
 		env_info: &'a EnvInfo,
 		machine: &'a Machine,
@@ -123,37 +102,6 @@ impl<'a, T: 'a, V: 'a, X: 'a, B: 'a> Externalities<'a, T, V, X, B>
 		ext_tracer: &'a mut X,
 		static_flag: bool,
 		storage: &'a Storage,
-	) -> Self {
-		Externalities {
-			state: state,
-			env_info: env_info,
-			machine: machine,
-			depth: depth,
-			origin_info: origin_info,
-			substate: substate,
-			schedule: machine.schedule(env_info.number),
-			output: output,
-			tracer: tracer,
-			vm_tracer: vm_tracer,
-			ext_tracer: ext_tracer,
-			static_flag: static_flag,
-			storage: storage,
-			encryption_key: None,
-		}
-	}
-	#[cfg(not(feature = "gateway"))]
-	pub fn new(state: &'a mut State<B>,
-		env_info: &'a EnvInfo,
-		machine: &'a Machine,
-		depth: usize,
-		origin_info: OriginInfo,
-		substate: &'a mut Substate,
-		output: OutputPolicy<'a, 'a>,
-		tracer: &'a mut T,
-		vm_tracer: &'a mut V,
-		ext_tracer: &'a mut X,
-		static_flag: bool,
-		storage: &'a mut Storage,
 	) -> Self {
 		Externalities {
 			state: state,

--- a/ethcore/src/storage.rs
+++ b/ethcore/src/storage.rs
@@ -3,10 +3,7 @@ use vm::Result;
 
 pub trait Storage {
 	fn fetch_bytes(&self, key: &H256) -> Result<Vec<u8>>;
-	#[cfg(feature = "gateway")]
 	fn store_bytes(&self, bytes: &[u8]) -> Result<H256>;
-	#[cfg(not(feature = "gateway"))]
-	fn store_bytes(&mut self, bytes: &[u8]) -> Result<H256>;
 }
 
 pub struct NullStorage;
@@ -22,13 +19,7 @@ impl Storage for NullStorage {
 		unimplemented!();
 	}
 
-	#[cfg(feature = "gateway")]
 	fn store_bytes(&self, _bytes: &[u8]) -> Result<H256> {
-		unimplemented!();
-	}
-
-	#[cfg(not(feature = "gateway"))]
-	fn store_bytes(&mut self, _bytes: &[u8]) -> Result<H256> {
 		unimplemented!();
 	}
 }


### PR DESCRIPTION
With this change, the runtime and gateway can use the same version of ethcore, without any feature flags.