### PR TITLE
Make authcodes module public

### DIFF
--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -100,7 +100,7 @@ extern crate tempdir;
 
 pub extern crate jsonrpc_ws_server as ws;
 
-mod authcodes;
+pub mod authcodes;
 pub mod http_common;
 pub mod v1;
 


### PR DESCRIPTION
In support of a fix for https://github.com/oasislabs/runtime-ethereum/issues/363