### PR TITLE
Re-re-enable floats

### DIFF
--- a/ethcore/wasm/src/parser.rs
+++ b/ethcore/wasm/src/parser.rs
@@ -33,7 +33,7 @@ fn gas_rules(wasm_costs: &vm::WasmCosts) -> rules::Set {
 			vals
 		})
 		.with_grow_cost(wasm_costs.grow_mem)
-		// .with_forbidden_floats()
+		.with_forbidden_floats()
 }
 
 /// Splits payload to code and data according to params.params_type, also


### PR DESCRIPTION
Allow floats, assuming that we are able to satisfy the criteria outlined in https://github.com/oasislabs/wasmi/issues/1.