### PR TITLE
ci: run ethcore-transaction tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,5 +31,4 @@ jobs:
       # Test ethcore
       - run:
           name: Run ethcore tests
-          working_directory: ethcore
-          command: cargo test
+          command: cargo test --package ethcore --package ethcore-transaction --package ethkey --features "ethkey-test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,6 +98,7 @@ slow-blocks = ["ethcore/slow-blocks"]
 secretstore = ["ethcore-secretstore"]
 final = ["parity-version/final"]
 deadlock_detection = ["parking_lot/deadlock_detection"]
+ethkey-test = ["ethkey/test"]
 
 [lib]
 path = "parity/lib.rs"

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -735,8 +735,7 @@ mod tests {
 	use std::sync::Arc;
 	use std::str::FromStr;
 	use rustc_hex::FromHex;
-	// use ethkey::{Generator, Random};
-	use ethkey::{KeyPair, Secret};
+	use ethkey::{Generator, Random};
 	use super::*;
 	use ethereum_types::{H256, U256, U512, Address};
 	use bytes::BytesRef;
@@ -761,15 +760,6 @@ mod tests {
 		let mut machine = ::ethereum::new_byzantium_test_machine();
 		machine.set_schedule_creation_rules(Box::new(move |s, _| s.max_depth = max_depth));
 		machine
-	}
-
-	// Using a static keypair for now, derived from a valid secret.
-	fn get_keypair() -> KeyPair {
-		KeyPair::from_secret(
-			Secret::from(
-				"0000000000000000000000000000000000000000000000000000000000000001",
-			)
-		).unwrap()
 	}
 
 	#[test]
@@ -1436,7 +1426,7 @@ mod tests {
 	// TODO: fix (preferred) or remove
 	evm_test_ignore!{test_transact_simple: test_transact_simple_int}
 	fn test_transact_simple(factory: Factory) {
-		let keypair = get_keypair();
+		let keypair = Random.generate().unwrap();
 		let t = Transaction {
 			action: Action::Create,
 			value: U256::from(17),
@@ -1475,7 +1465,7 @@ mod tests {
 
 	evm_test!{test_transact_invalid_nonce: test_transact_invalid_nonce_int}
 	fn test_transact_invalid_nonce(factory: Factory) {
-		let keypair = get_keypair();
+		let keypair = Random.generate().unwrap();
 		let t = Transaction {
 			action: Action::Create,
 			value: U256::from(17),
@@ -1508,7 +1498,7 @@ mod tests {
 
 	evm_test!{test_transact_gas_limit_reached: test_transact_gas_limit_reached_int}
 	fn test_transact_gas_limit_reached(factory: Factory) {
-		let keypair = get_keypair();
+		let keypair = Random.generate().unwrap();
 		let t = Transaction {
 			action: Action::Create,
 			value: U256::from(17),
@@ -1543,7 +1533,7 @@ mod tests {
 	evm_test!{test_not_enough_cash: test_not_enough_cash_int}
 	fn test_not_enough_cash(factory: Factory) {
 
-		let keypair = get_keypair();
+		let keypair = Random.generate().unwrap();
 		let t = Transaction {
 			action: Action::Create,
 			value: U256::from(18),

--- a/ethkey/Cargo.toml
+++ b/ethkey/Cargo.toml
@@ -14,3 +14,7 @@ mem = { path = "../util/mem" }
 quick-error = "1.2"
 rustc-hex = "1.0"
 tiny-keccak = "1.4"
+rand = { version = "0.3", optional = true }
+
+[features]
+test = ["secp256k1-plus/rand", "rand"]

--- a/ethkey/src/lib.rs
+++ b/ethkey/src/lib.rs
@@ -24,7 +24,8 @@ extern crate mem;
 // extern crate parity_wordlist;
 #[macro_use]
 extern crate quick_error;
-// extern crate rand;
+#[cfg(any(test, feature = "test"))]
+extern crate rand;
 extern crate rustc_hex;
 extern crate secp256k1;
 extern crate tiny_keccak;
@@ -40,7 +41,8 @@ mod error;
 mod keypair;
 mod keccak;
 // mod prefix;
-// mod random;
+#[cfg(any(test, feature = "test"))]
+mod random;
 mod signature;
 mod secret;
 // mod extended;
@@ -56,7 +58,8 @@ pub use self::error::Error;
 pub use self::keypair::{KeyPair, public_to_address};
 // pub use self::math::public_is_valid;
 // pub use self::prefix::Prefix;
-// pub use self::random::Random;
+#[cfg(any(test, feature = "test"))]
+pub use self::random::Random;
 pub use self::signature::{sign, verify_public, verify_address, recover, Signature};
 //pub use self::signature::{recover, Signature};
 pub use self::secret::Secret;
@@ -71,14 +74,16 @@ lazy_static! {
 	pub static ref SECP256K1: secp256k1::Secp256k1 = secp256k1::Secp256k1::new();
 }
 
-// /// Uninstantiatable error type for infallible generators.
-// #[derive(Debug)]
-// pub enum Void {}
-//
-// /// Generates new keypair.
-// pub trait Generator {
-// 	type Error;
-//
-// 	/// Should be called to generate new keypair.
-// 	fn generate(&mut self) -> Result<KeyPair, Self::Error>;
-// }
+/// Uninstantiatable error type for infallible generators.
+#[cfg(any(test, feature = "test"))]
+#[derive(Debug)]
+pub enum Void {}
+
+/// Generates new keypair.
+#[cfg(any(test, feature = "test"))]
+pub trait Generator {
+	type Error;
+
+	/// Should be called to generate new keypair.
+	fn generate(&mut self) -> Result<KeyPair, Self::Error>;
+}


### PR DESCRIPTION
Background: we will be adding some new code to `ethcore-transaction` as part of https://github.com/oasislabs/runtime-ethereum/issues/469. So we want to run tests for this package.

Also run `ethkey` tests (`ethkey-test` feature is needed for `ethcore-transaction` tests)