### PR TITLE
Fail calls to expired contracts

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -403,7 +403,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 			return Err(vm::Error::MutableCallInStaticContext);
 		}
 
-		// fail the call immediately if the contract is expired
+		// Fail the call immediately if the contract is expired.
 		if self.info.timestamp > self.state.storage_expiry(&params.code_address)? {
 			let trace_info = tracer.prepare_trace_call(&params);
 			tracer.trace_failed_call(trace_info, vec![], vm::Error::Reverted.into());


### PR DESCRIPTION
See #74 

Will add a test in `runtime-ethereum` once we have the end-to-end flow for specifying expiry at deploy time (i.e., deployment header)