### PR TITLE
Only check expiry for contract calls

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -403,8 +403,8 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 			return Err(vm::Error::MutableCallInStaticContext);
 		}
 
-		// Fail the call immediately if the contract is expired.
-		if self.info.timestamp > self.state.storage_expiry(&params.code_address)? {
+		// Fail immediately if this is a call to an expired contract.
+		if params.code.is_some() && self.info.timestamp > self.state.storage_expiry(&params.code_address)? {
 			let trace_info = tracer.prepare_trace_call(&params);
 			tracer.trace_failed_call(trace_info, vec![], vm::Error::Reverted.into());
 			return Err(vm::Error::Reverted);


### PR DESCRIPTION
The previous code reverted balance transfers to non-contract accounts as they have no expiry (`expiry == 0`).