### PR TITLE
Improve truffle error messages

### DIFF
--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -395,7 +395,7 @@ pub fn vm(error: &VMError, output: &[u8]) -> Error {
 
 	Error {
 		code: ErrorCode::ServerError(codes::EXECUTION_ERROR),
-		message: "VM execution error.".into(),
+		message: format!("VM execution error: {}", data).into(),
 		data: Some(Value::String(data)),
 	}
 }


### PR DESCRIPTION
[web3-provider-engine eats the extra data provided with an error](https://github.com/MetaMask/provider-engine/blob/master/subproviders/provider.js#L19). It's the difference between: `VM execution error` and `VM execution error: Wasm runtime error: Instantiation("Export __tvm_module_startup not found")`

Ideally, we'd fix this in `web3-provider-engine` since `data` is [part of the JSON RPC spec](https://github.com/ethereum/wiki/wiki/JSON-RPC-Error-Codes-Improvement-Proposal), but we don't already have a fork.