### PR TITLE
Don't use system time for block timestamp

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -299,7 +299,8 @@ impl<'x> OpenBlock<'x> {
 		r.block.header.set_parent_hash(parent.hash());
 		r.block.header.set_number(number);
 		r.block.header.set_author(author);
-		r.block.header.set_timestamp(engine.open_block_header_timestamp(parent.timestamp()));
+		// No need to initialize the timestamp here. We'll set it later before closing the block.
+		//r.block.header.set_timestamp(engine.open_block_header_timestamp(parent.timestamp()));
 		r.block.header.set_extra_data(extra_data);
 
 		//let gas_floor_target = cmp::max(gas_range_target.0, engine.params().min_gas_limit);


### PR DESCRIPTION
We overwrite this value value anyway, here: https://github.com/oasislabs/runtime-ethereum/blob/f06d784c382c50fae69cec37bfc7ca2b1602a50c/src/lib.rs#L133