### PR TITLE
add complete transaction kind for pubsub

### DIFF
--- a/rpc/src/v1/types/pubsub.rs
+++ b/rpc/src/v1/types/pubsub.rs
@@ -60,6 +60,9 @@ pub enum Kind {
 	/// Node syncing status subscription.
 	#[serde(rename="syncing")]
 	Syncing,
+	/// Completed Transactions subscription.
+	#[serde(rename="completedTransaction")]
+	CompletedTransaction,
 }
 
 /// Subscription kind.


### PR DESCRIPTION
Going to implement https://eips.ethereum.org/EIPS/eip-758, so we need a new subscription type.