### PR TITLE
Fix rocksdb dependency

### DIFF
--- a/util/kvdb-rocksdb/Cargo.toml
+++ b/util/kvdb-rocksdb/Cargo.toml
@@ -11,7 +11,7 @@ log = "0.3"
 num_cpus = "1.0"
 parking_lot = "0.5"
 regex = "0.2"
-rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }
+parity-rocksdb = { git = "https://github.com/paritytech/rust-rocksdb" }
 interleaved-ordered = "0.1.0"
 
 [dev-dependencies]

--- a/util/kvdb-rocksdb/src/lib.rs
+++ b/util/kvdb-rocksdb/src/lib.rs
@@ -22,7 +22,7 @@ extern crate interleaved_ordered;
 extern crate num_cpus;
 extern crate parking_lot;
 extern crate regex;
-extern crate rocksdb;
+extern crate parity_rocksdb;
 
 extern crate ethereum_types;
 extern crate kvdb;
@@ -34,7 +34,7 @@ use std::path::{PathBuf, Path};
 use std::{fs, io, mem, result};
 
 use parking_lot::{Mutex, MutexGuard, RwLock};
-use rocksdb::{
+use parity_rocksdb::{
 	DB, Writable, WriteBatch, WriteOptions, IteratorMode, DBIterator,
 	Options, BlockBasedOptions, Direction, Cache, Column, ReadOptions
 };


### PR DESCRIPTION
`rocksdb` was renamed to `parity-rocksdb`