### PR TITLE
Use codehash when deriving addresses

### DIFF
--- a/ethcore/evm/src/instructions.rs
+++ b/ethcore/evm/src/instructions.rs
@@ -303,7 +303,7 @@ lazy_static! {
 		arr[DELEGATECALL as usize] =	InstructionInfo::new("DELEGATECALL",	6, 1, GasPriceTier::Special);
 		arr[STATICCALL as usize] =		InstructionInfo::new("STATICCALL",		6, 1, GasPriceTier::Special);
 		arr[SUICIDE as usize] = 		InstructionInfo::new("SUICIDE",			1, 0, GasPriceTier::Special);
-		arr[CREATE2 as usize] = 		InstructionInfo::new("CREATE2",			3, 1, GasPriceTier::Special);
+		arr[CREATE2 as usize] =         InstructionInfo::new("CREATE2",         4, 1, GasPriceTier::Special);
 		arr[REVERT as usize] =			InstructionInfo::new("REVERT",			2, 0, GasPriceTier::Zero);
 		arr
 	};

--- a/ethcore/evm/src/interpreter/gasometer.rs
+++ b/ethcore/evm/src/interpreter/gasometer.rs
@@ -235,7 +235,11 @@ impl<Gas: evm::CostType> Gasometer<Gas> {
 			}
 			instructions::CREATE | instructions::CREATE2 => {
 				let gas = Gas::from(schedule.create_gas);
-				let mem = mem_needed(stack.peek(1), stack.peek(2))?;
+				let mem = match instruction {
+					instructions::CREATE => mem_needed(stack.peek(1), stack.peek(2))?,
+					instructions::CREATE2 => mem_needed(stack.peek(2), stack.peek(3))?,
+					_ => unreachable!("instruction can only be CREATE/CREATE2 checked above; qed"),
+				};
 
 				Request::GasMemProvide(gas, mem, None)
 			}

--- a/ethcore/evm/src/interpreter/mod.rs
+++ b/ethcore/evm/src/interpreter/mod.rs
@@ -361,6 +361,13 @@ impl<Cost: CostType> Interpreter<Cost> {
 			}
 			instructions::CREATE | instructions::CREATE2 => {
 				let endowment = stack.pop_back();
+				let address_scheme = match instruction {
+					instructions::CREATE => CreateContractAddress::FromSenderAndNonce,
+					instructions::CREATE2 => {
+						CreateContractAddress::FromSenderSaltAndCodeHash(stack.pop_back().into())
+					}
+					_ => unreachable!("instruction can only be CREATE/CREATE2 checked above; qed"),
+				};
 				let init_off = stack.pop_back();
 				let init_size = stack.pop_back();
 
@@ -381,11 +388,6 @@ impl<Cost: CostType> Interpreter<Cost> {
 				}
 
 				let contract_code = self.mem.read_slice(init_off, init_size);
-				let address_scheme = if instruction == instructions::CREATE {
-					CreateContractAddress::FromSenderAndNonce
-				} else {
-					CreateContractAddress::FromSenderAndCodeHash
-				};
 
 				let create_result = ext.create(
 					&create_gas.as_u256(),

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -450,7 +450,7 @@ pub trait EthEngine: Engine<::machine::EthereumMachine> {
 
 	/// Returns new contract address generation scheme at given block number.
 	fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
-		self.machine().create_address_scheme(number)
+		self.machine().create_address_scheme(number, H256::zero())
 	}
 
 	/// Verify a particular transaction is valid.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -450,7 +450,7 @@ pub trait EthEngine: Engine<::machine::EthereumMachine> {
 
 	/// Returns new contract address generation scheme at given block number.
 	fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
-		self.machine().create_address_scheme(number, H256::zero())
+		unreachable!("address scheme is created directly from `EthereumMachine`")
 	}
 
 	/// Verify a particular transaction is valid.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -450,7 +450,7 @@ pub trait EthEngine: Engine<::machine::EthereumMachine> {
 
 	/// Returns new contract address generation scheme at given block number.
 	fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
-		unreachable!("address scheme is created directly from `EthereumMachine`")
+		self.machine().create_address_scheme(number)
 	}
 
 	/// Verify a particular transaction is valid.

--- a/ethcore/src/executed.rs
+++ b/ethcore/src/executed.rs
@@ -117,6 +117,8 @@ pub enum ExecutionError {
 	TransactionMalformed(String),
 	/// Returned when a non-confidential transaction execution is requested in confidential mode.
 	NotConfidential,
+	/// For confidential transactions, the code at address was not what was expected.
+	InvalidCode,
 }
 
 impl From<Box<trie::TrieError>> for ExecutionError {
@@ -169,6 +171,7 @@ impl fmt::Display for ExecutionError {
 			SenderMustExist => write!(f, "Transacting from an empty account"),
 			Internal(ref msg) => write!(f, "{}", msg),
 			TransactionMalformed(ref err) => write!(f, "Malformed transaction: {}", err),
+			InvalidCode => write!(f, "Invalid code found in state"),
 			NotConfidential => write!(
 				f,
 				"Tried executing a non-confidential transaction in confidential mode"

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -334,7 +334,9 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 			.map_err(|e| ExecutionError::TransactionMalformed(e))?;
 
 		let schedule = self.machine.schedule(self.info.number);
-		let confidential = oasis_contract.as_ref().map_or(false, |c| c.confidential);
+		let confidential = oasis_contract
+			.as_ref()
+			.map_or(false, |c| c.is_confidential());
 		let base_gas_required = U256::from(t.gas_required(&schedule, confidential));
 
 		if t.gas < base_gas_required {

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -400,7 +400,10 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 		let (result, output) = match t.action {
 			Action::Create => {
 				let (new_address, code_hash) = contract_address(
-					self.machine.create_address_scheme(self.info.number),
+					self.machine.create_address_scheme(
+						self.info.number,
+						*self.info.last_hashes.first().unwrap(),
+					),
 					&sender,
 					&nonce,
 					&t.data,

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -68,10 +68,12 @@ pub fn contract_address(
 			stream.append(nonce);
 			(From::from(keccak(stream.as_raw())), None)
 		}
-		CreateContractAddress::FromCodeHash => {
+		CreateContractAddress::FromSenderSaltAndCodeHash(salt) => {
 			let code_hash = keccak(code);
-			let mut buffer = [0xffu8; 20 + 32];
-			&mut buffer[20..].copy_from_slice(&code_hash[..]);
+			let mut buffer = [0u8; 20 + 32 + 32];
+			&mut buffer[0..20].copy_from_slice(&sender[..]);
+			&mut buffer[20..(20 + 32)].copy_from_slice(&salt[..]);
+			&mut buffer[(20 + 32)..].copy_from_slice(&code_hash[..]);
 			(From::from(keccak(&buffer[..])), Some(code_hash))
 		}
 		CreateContractAddress::FromSenderAndCodeHash => {

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -388,7 +388,7 @@ impl<'a, B: 'a + StateBackend> Executive<'a, B> {
 		let mut substate = Substate::new();
 
 		// NOTE: there can be no invalid transactions from this point.
-		if !schedule.eip86 || !t.is_unsigned() {
+		if !t.is_unsigned() {
 			self.state.inc_nonce(&sender)?;
 		}
 		self.state.sub_balance(

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -901,4 +901,86 @@ mod tests {
 
 		assert_eq!(setup.sub_state.suicides.len(), 1);
 	}
+
+	#[test]
+	fn can_create() {
+		use std::str::FromStr;
+
+		let mut setup = TestSetup::new();
+		let state = &mut setup.state;
+		let mut tracer = NoopTracer;
+		let mut vm_tracer = NoopVMTracer;
+		let mut ext_tracer = NoopExtTracer;
+
+		let address = {
+			let mut ext = Externalities::new(
+				state,
+				&setup.env_info,
+				&setup.machine,
+				0,
+				get_test_origin(),
+				&mut setup.sub_state,
+				OutputPolicy::InitContract(None),
+				&mut tracer,
+				&mut vm_tracer,
+				&mut ext_tracer,
+				false,
+			);
+			match ext.create(
+				&U256::max_value(),
+				&U256::zero(),
+				&[],
+				CreateContractAddress::FromSenderAndNonce,
+			) {
+				ContractCreateResult::Created(address, _) => address,
+				_ => panic!("Test create failed; expected Created, got Failed/Reverted."),
+			}
+		};
+
+		assert_eq!(
+			address,
+			Address::from_str("bd770416a3345f91e4b34576cb804a576fa48eb1").unwrap()
+		);
+	}
+
+	#[test]
+	fn can_create2() {
+		use std::str::FromStr;
+
+		let mut setup = TestSetup::new();
+		let state = &mut setup.state;
+		let mut tracer = NoopTracer;
+		let mut vm_tracer = NoopVMTracer;
+		let mut ext_tracer = NoopExtTracer;
+
+		let address = {
+			let mut ext = Externalities::new(
+				state,
+				&setup.env_info,
+				&setup.machine,
+				0,
+				get_test_origin(),
+				&mut setup.sub_state,
+				OutputPolicy::InitContract(None),
+				&mut tracer,
+				&mut vm_tracer,
+				&mut ext_tracer,
+				false,
+			);
+			match ext.create(
+				&U256::max_value(),
+				&U256::zero(),
+				&[],
+				CreateContractAddress::FromSenderSaltAndCodeHash(H256::default()),
+			) {
+				ContractCreateResult::Created(address, _) => address,
+				_ => panic!("Test create failed; expected Created, got Failed/Reverted."),
+			}
+		};
+
+		assert_eq!(
+			address,
+			Address::from_str("b7c227636666831278bacdb8d7f52933b8698ab9").unwrap()
+		);
+	}
 }

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -253,12 +253,15 @@ where
 					.borrow()
 					.activated()
 			{
+				let salt = match address_scheme {
+					CreateContractAddress::FromSaltAndCodeHash(salt) => salt,
+					_ => unreachable!(
+						"confidential `create` must have address derived from salt and code hash"
+					),
+				};
 				let mut header_code = OasisContract::make_header(
 					1,
-					json!({
-						"confidential": true
-					})
-					.to_string(),
+					json!({ "salt_if_confidential": salt }).to_string(),
 				);
 				header_code.append(&mut code.to_vec());
 				header_code

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -307,7 +307,7 @@ where
 		};
 
 		if !self.static_flag {
-			if !self.schedule.eip86 || params.sender != UNSIGNED_SENDER {
+			if params.sender != UNSIGNED_SENDER {
 				if let Err(e) = self.state.inc_nonce(&self.origin_info.address) {
 					debug!(target: "ext", "Database corruption encountered: {:?}", e);
 					return ContractCreateResult::Failed;

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -34,7 +34,7 @@ use transaction::{self, SignedTransaction, UnverifiedTransaction, SYSTEM_ADDRESS
 // use tx_filter::TransactionFilter;
 
 use bytes::BytesRef;
-use ethereum_types::{Address, H256, U256};
+use ethereum_types::{Address, U256};
 use rlp::Rlp;
 use vm::{ActionParams, ActionValue, CallType, OasisContract, ParamsType};
 use vm::{CreateContractAddress, EnvInfo, Schedule};

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -34,7 +34,7 @@ use transaction::{self, SignedTransaction, UnverifiedTransaction, SYSTEM_ADDRESS
 // use tx_filter::TransactionFilter;
 
 use bytes::BytesRef;
-use ethereum_types::{Address, U256};
+use ethereum_types::{Address, H256, U256};
 use rlp::Rlp;
 use vm::{ActionParams, ActionValue, CallType, OasisContract, ParamsType};
 use vm::{CreateContractAddress, EnvInfo, Schedule};
@@ -371,12 +371,7 @@ impl EthereumMachine {
 	}
 
 	/// Returns new contract address generation scheme at given block number.
-	pub fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
-		let mut salt = ethereum_types::H256::new();
-		#[cfg(not(test))]
-		{
-			rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, salt.as_mut());
-		}
+	pub fn create_address_scheme(&self, number: BlockNumber, salt: H256) -> CreateContractAddress {
 		CreateContractAddress::FromSenderSaltAndCodeHash(salt)
 	}
 

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -371,8 +371,8 @@ impl EthereumMachine {
 	}
 
 	/// Returns new contract address generation scheme at given block number.
-	pub fn create_address_scheme(&self, number: BlockNumber, salt: H256) -> CreateContractAddress {
-		CreateContractAddress::FromSenderSaltAndCodeHash(salt)
+	pub fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
+		CreateContractAddress::FromSenderAndNonce
 	}
 
 	/// Verify a particular transaction is valid, regardless of order.

--- a/ethcore/src/machine.rs
+++ b/ethcore/src/machine.rs
@@ -372,11 +372,12 @@ impl EthereumMachine {
 
 	/// Returns new contract address generation scheme at given block number.
 	pub fn create_address_scheme(&self, number: BlockNumber) -> CreateContractAddress {
-		if number >= self.params().eip86_transition {
-			CreateContractAddress::FromCodeHash
-		} else {
-			CreateContractAddress::FromSenderAndNonce
+		let mut salt = ethereum_types::H256::new();
+		#[cfg(not(test))]
+		{
+			rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, salt.as_mut());
 		}
+		CreateContractAddress::FromSenderSaltAndCodeHash(salt)
 	}
 
 	/// Verify a particular transaction is valid, regardless of order.

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -104,8 +104,6 @@ pub struct CommonParams {
 	pub validate_receipts_transition: BlockNumber,
 	/// Validate transaction chain id.
 	pub validate_chain_id_transition: BlockNumber,
-	/// Number of first block where EIP-86 (Metropolis) rules begin.
-	pub eip86_transition: BlockNumber,
 	/// Number of first block where EIP-140 (Metropolis: REVERT opcode) rules begin.
 	pub eip140_transition: BlockNumber,
 	/// Number of first block where EIP-210 (Metropolis: BLOCKHASH changes) rules begin.
@@ -179,7 +177,7 @@ impl CommonParams {
 
 	/// Apply common spec config parameters to the schedule.
 	pub fn update_schedule(&self, block_number: u64, schedule: &mut ::vm::Schedule) {
-		schedule.have_create2 = block_number >= self.eip86_transition;
+		schedule.have_create2 = true;
 		schedule.have_revert = block_number >= self.eip140_transition;
 		schedule.have_static_call = block_number >= self.eip214_transition;
 		schedule.have_return_data = block_number >= self.eip211_transition;
@@ -200,16 +198,7 @@ impl CommonParams {
 
 	/// Whether these params contain any bug-fix hard forks.
 	pub fn contains_bugfix_hard_fork(&self) -> bool {
-		self.eip98_transition != 0
-			&& self.eip155_transition != 0
-			&& self.validate_receipts_transition != 0
-			&& self.eip86_transition != 0
-			&& self.eip140_transition != 0
-			&& self.eip210_transition != 0
-			&& self.eip211_transition != 0
-			&& self.eip214_transition != 0
-			&& self.validate_chain_id_transition != 0
-			&& self.dust_protection_transition != 0
+		true
 	}
 }
 
@@ -239,9 +228,6 @@ impl From<ethjson::spec::Params> for CommonParams {
 			eip155_transition: p.eip155_transition.map_or(0, Into::into),
 			validate_receipts_transition: p.validate_receipts_transition.map_or(0, Into::into),
 			validate_chain_id_transition: p.validate_chain_id_transition.map_or(0, Into::into),
-			eip86_transition: p
-				.eip86_transition
-				.map_or_else(BlockNumber::max_value, Into::into),
 			eip140_transition: p
 				.eip140_transition
 				.map_or_else(BlockNumber::max_value, Into::into),

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -1537,10 +1537,6 @@ mod tests {
 		let mut state = get_temp_state();
 
 		let mut info = EnvInfo::default();
-		info.last_hashes = Arc::new(vec![H256::from_str(
-			"9f1897f227a8a843c0961a5227709fa962dc6860a2129750fdb450f48d7459bb",
-		)
-		.unwrap()]);
 		info.gas_limit = 1_000_000.into();
 		let machine = make_frontier_machine(5);
 
@@ -1573,7 +1569,7 @@ mod tests {
 			}),
 			result: trace::Res::Create(trace::CreateResult {
 				gas_used: U256::from(40),
-				address: Address::from_str("f55820d083087a5e3dfc39a36273bcc3eb2f23fe").unwrap(),
+				address: Address::from_str("8988167e088c87cd314df6d3c2b83da5acb93ace").unwrap(),
 				code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53],
 			}),
 		}];

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -1602,10 +1602,6 @@ mod tests {
 		let mut state = get_temp_state();
 
 		let mut info = EnvInfo::default();
-		info.last_hashes = Arc::new(vec![H256::from_str(
-			"9f1897f227a8a843c0961a5227709fa962dc6860a2129750fdb450f48d7459bb",
-		)
-		.unwrap()]);
 		info.gas_limit = 1_000_000.into();
 		let machine = make_frontier_machine(5);
 

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -1569,7 +1569,7 @@ mod tests {
 			}),
 			result: trace::Res::Create(trace::CreateResult {
 				gas_used: U256::from(40),
-				address: Address::from_str("8988167e088c87cd314df6d3c2b83da5acb93ace").unwrap(),
+				address: Address::from_str("1cac9669e3248c02ee6c0cb76c8737c421d3c455").unwrap(),
 				code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53],
 			}),
 		}];

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -1537,6 +1537,10 @@ mod tests {
 		let mut state = get_temp_state();
 
 		let mut info = EnvInfo::default();
+		info.last_hashes = Arc::new(vec![H256::from_str(
+			"9f1897f227a8a843c0961a5227709fa962dc6860a2129750fdb450f48d7459bb",
+		)
+		.unwrap()]);
 		info.gas_limit = 1_000_000.into();
 		let machine = make_frontier_machine(5);
 
@@ -1569,7 +1573,7 @@ mod tests {
 			}),
 			result: trace::Res::Create(trace::CreateResult {
 				gas_used: U256::from(40),
-				address: Address::from_str("1cac9669e3248c02ee6c0cb76c8737c421d3c455").unwrap(),
+				address: Address::from_str("f55820d083087a5e3dfc39a36273bcc3eb2f23fe").unwrap(),
 				code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53],
 			}),
 		}];
@@ -1602,6 +1606,10 @@ mod tests {
 		let mut state = get_temp_state();
 
 		let mut info = EnvInfo::default();
+		info.last_hashes = Arc::new(vec![H256::from_str(
+			"9f1897f227a8a843c0961a5227709fa962dc6860a2129750fdb450f48d7459bb",
+		)
+		.unwrap()]);
 		info.gas_limit = 1_000_000.into();
 		let machine = make_frontier_machine(5);
 

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -1355,7 +1355,7 @@ impl<B: Backend> State<B> {
 			}
 		};
 
-		Ok(contract.as_ref().map_or(false, |c| c.confidential))
+		Ok(contract.as_ref().map_or(false, |c| c.is_confidential()))
 	}
 
 	pub fn is_encrypting(&self) -> bool {

--- a/ethcore/vm/src/ext.rs
+++ b/ethcore/vm/src/ext.rs
@@ -53,11 +53,11 @@ pub enum MessageCallResult {
 /// Specifies how an address is calculated for a new contract.
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub enum CreateContractAddress {
-	/// Address is calculated from nonce and sender. Pre EIP-86 (Metropolis)
+	/// Address is calculated from sender and nonce. Pre EIP-86 (Metropolis)
 	FromSenderAndNonce,
-	/// Address is calculated from code hash. Default since EIP-86
-	FromCodeHash,
-	/// Address is calculated from code hash and sender. Used by CREATE_P2SH instruction.
+	/// Address is calculated from sender, salt and code hash. EIP-86 CREATE2 scheme.
+	FromSenderSaltAndCodeHash(H256),
+	/// Address is calculated from code hash and sender. Used by pwasm create ext.
 	FromSenderAndCodeHash,
 }
 

--- a/ethcore/vm/src/ext.rs
+++ b/ethcore/vm/src/ext.rs
@@ -57,6 +57,9 @@ pub enum CreateContractAddress {
 	FromSenderAndNonce,
 	/// Address is calculated from sender, salt and code hash. EIP-86 CREATE2 scheme.
 	FromSenderSaltAndCodeHash(H256),
+	/// Address is calculated from salt and code hash. Similar to EIP-86 CREATE2 scheme
+	/// except that the Addreess MAC can be verified without knowing the creator.
+	FromSaltAndCodeHash(H256),
 	/// Address is calculated from code hash and sender. Used by pwasm create ext.
 	FromSenderAndCodeHash,
 }

--- a/ethcore/vm/src/oasis_vm.rs
+++ b/ethcore/vm/src/oasis_vm.rs
@@ -100,7 +100,7 @@ impl ConfidentialVm {
 			Ok(params
 				.oasis_contract
 				.as_ref()
-				.map_or(false, |c| c.confidential))
+				.map_or(false, |c| c.salt_if_confidential.is_some()))
 		}
 		// If we haven't executed a confidential contract in this transaction yet, check
 		// if the target contract is confidential. Don't check the given oasis_contract

--- a/ethcore/vm/src/oasis_vm.rs
+++ b/ethcore/vm/src/oasis_vm.rs
@@ -100,7 +100,7 @@ impl ConfidentialVm {
 			Ok(params
 				.oasis_contract
 				.as_ref()
-				.map_or(false, |c| c.salt_if_confidential.is_some()))
+				.map_or(false, |c| c.is_confidential()))
 		}
 		// If we haven't executed a confidential contract in this transaction yet, check
 		// if the target contract is confidential. Don't check the given oasis_contract

--- a/ethcore/vm/src/schedule.rs
+++ b/ethcore/vm/src/schedule.rs
@@ -115,8 +115,6 @@ pub struct Schedule {
 	pub have_bitwise_shifting: bool,
 	/// Kill basic accounts below this balance if touched.
 	pub kill_dust: CleanDustMode,
-	/// Enable EIP-86 rules
-	pub eip86: bool,
 	/// Wasm extra schedule settings, if wasm activated
 	pub wasm: Option<WasmCosts>,
 	/// Default storage duration (in seconds)
@@ -262,7 +260,6 @@ impl Schedule {
 			blockhash_gas: 20,
 			have_static_call: false,
 			kill_dust: CleanDustMode::Off,
-			eip86: false,
 			wasm: None,
 			default_storage_duration: 3155695200, // 100 years
 		}
@@ -334,7 +331,6 @@ impl Schedule {
 			blockhash_gas: 20,
 			have_static_call: false,
 			kill_dust: CleanDustMode::Off,
-			eip86: false,
 			wasm: None,
 			default_storage_duration: 3155695200, // 100 years
 		}

--- a/ethcore/vm/src/schedule.rs
+++ b/ethcore/vm/src/schedule.rs
@@ -24,7 +24,7 @@ pub struct Schedule {
 	pub exceptional_failed_code_deposit: bool,
 	/// Does it have a delegate cal
 	pub have_delegate_call: bool,
-	/// Does it have a CREATE_P2SH instruction
+	/// Does it have a CREATE2 instruction
 	pub have_create2: bool,
 	/// Does it have a REVERT instruction
 	pub have_revert: bool,

--- a/ethcore/wasm/src/lib.rs
+++ b/ethcore/wasm/src/lib.rs
@@ -255,10 +255,11 @@ fn subst_main_call(module: &mut elements::Module) -> bool {
 		Some(idx) => idx,
 		None => return false,
 	};
-	let main_fn_idx = match func_index(module, "main") {
-		Some(idx) => idx,
-		None => return false,
-	};
+	let main_fn_idx =
+		match func_index(module, "__original_main").or_else(|| func_index(module, "main")) {
+			Some(idx) => idx,
+			None => return false,
+		};
 
 	let import_section_len: usize = module
 		.import_section()

--- a/ethcore/wasmer/src/lib.rs
+++ b/ethcore/wasmer/src/lib.rs
@@ -209,20 +209,23 @@ impl vm::Vm for WasmRuntime {
 
 /// Replaces the call to `main` in `_start` with one to `_oasis_deploy`.
 fn subst_main_call(module: &mut Module) {
-	let module_info = module.info();
+	// let module_info = module.info();
+	//
+	// let start_fn_idx = match func_index(module_info, "_start") {
+	// 	Some(idx) => idx,
+	// 	None => return,
+	// };
+	// let deploy_fn_idx = match func_index(module_info, "_oasis_deploy") {
+	// 	Some(idx) => idx,
+	// 	None => return,
+	// };
+	// let main_fn_idx =
+	// 	match func_index(module, "__original_main").or_else(|| func_index(module, "main")) {
+	// 		Some(idx) => idx,
+	// 		None => return,
+	// 	};
 
-	let start_fn_idx = match func_index(module_info, "_start") {
-		Some(idx) => idx,
-		None => return,
-	};
-	let deploy_fn_idx = match func_index(module_info, "_oasis_deploy") {
-		Some(idx) => idx,
-		None => return,
-	};
-	let mut main_fn_idx = match func_index(module_info, "main") {
-		Some(idx) => idx,
-		None => return,
-	};
+	unimplemented!()
 
 	// TODO: Unimplemented
 	// Need to get mutable access to the exports and replace function index, same as in wasmi

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -79,9 +79,6 @@ pub struct Params {
 	#[serde(rename = "validateReceiptsTransition")]
 	pub validate_receipts_transition: Option<Uint>,
 	/// See `CommonParams` docs.
-	#[serde(rename = "eip86Transition")]
-	pub eip86_transition: Option<Uint>,
-	/// See `CommonParams` docs.
 	#[serde(rename = "eip140Transition")]
 	pub eip140_transition: Option<Uint>,
 	/// See `CommonParams` docs.

--- a/rpc/src/v1/types/transaction.rs
+++ b/rpc/src/v1/types/transaction.rs
@@ -256,29 +256,6 @@ impl Transaction {
 	}
 }
 
-/*impl LocalTransactionStatus {
-	/// Convert `LocalTransactionStatus` into RPC `LocalTransactionStatus`.
-	pub fn from(s: miner::pool::local_transactions::Status, block_number: u64, eip86_transition: u64) -> Self {
-		let convert = |tx: Arc<miner::pool::VerifiedTransaction>| {
-			Transaction::from_signed(tx.signed().clone(), block_number, eip86_transition)
-		};
-		use miner::pool::local_transactions::Status::*;
-		match s {
-			Pending(_) => LocalTransactionStatus::Pending,
-			Mined(tx) => LocalTransactionStatus::Mined(convert(tx)),
-			Dropped(tx) => LocalTransactionStatus::Dropped(convert(tx)),
-			Rejected(tx, reason) => LocalTransactionStatus::Rejected(convert(tx), reason),
-			Invalid(tx) => LocalTransactionStatus::Invalid(convert(tx)),
-			Canceled(tx) => LocalTransactionStatus::Canceled(convert(tx)),
-			Replaced { old, new } => LocalTransactionStatus::Replaced(
-				convert(old),
-				new.signed().gas_price.into(),
-				new.signed().hash().into(),
-			),
-		}
-	}
-}*/
-
 #[cfg(test)]
 mod tests {
 	use super::{LocalTransactionStatus, Transaction};


### PR DESCRIPTION
This PR

* cherry-picks https://github.com/paritytech/parity-ethereum/pull/9140
* makes `FromSaltAndCodeHash` the default address scheme for c10l contracts
* changes `confidiential: bool` in the deploy header to `salt_if_confidential: Option<Salt>`

tl;dr: for c10l contracts, the address becomes a MAC of the code. The address is generated from the salt, and codehash. The salt is provided as part of the deploy header (`salt_if_confidential`) or explicitly by a `CREATE2` call (and Wasm `create`, when it exists). This PR is useful for preventing subbing out the contract code at an address with a different contract.