### PR TITLE
Replace main function generated by nightly-2020-02-16

### DIFF
--- a/ethcore/wasm/src/lib.rs
+++ b/ethcore/wasm/src/lib.rs
@@ -255,10 +255,11 @@ fn subst_main_call(module: &mut elements::Module) -> bool {
 		Some(idx) => idx,
 		None => return false,
 	};
-	let main_fn_idx = match func_index(module, "main") {
-		Some(idx) => idx,
-		None => return false,
-	};
+	let main_fn_idx =
+		match func_index(module, "__original_main").or_else(|| func_index(module, "main")) {
+			Some(idx) => idx,
+			None => return false,
+		};
 
 	let import_section_len: usize = module
 		.import_section()


### PR DESCRIPTION
nightly-2020-02-16 generates the following code:

```diff
   (func $_start (type 0)
     (local i32)
     call $__wasm_call_ctors
-    call $main
+    call $__original_main
```
