### PR TITLE
Add RUST_BACKTRACE=1 to WASM env

### DIFF
--- a/ethcore/wasm/src/wasi.rs
+++ b/ethcore/wasm/src/wasi.rs
@@ -104,7 +104,7 @@ impl<'a> crate::Runtime<'a> {
 		environ: P<P<u8>>,
 		mut environ_buf: P<u8>,
 	) -> crate::Result<ErrNo> {
-		let environs = self.memory.get_mut(environ, 4)?;
+		let environs = self.memory.get_mut(environ, 5)?;
 		environs[0] = environ_buf;
 		environ_buf = self.memory.set(
 			environ_buf,
@@ -125,6 +125,9 @@ impl<'a> crate::Runtime<'a> {
 			environ_buf,
 			format!("VALUE={}\0", self.context.value_str).as_bytes(),
 		)?;
+		environs[4] = environ_buf;
+		self.memory
+			.set(environ_buf, "RUST_BACKTRACE=1\0".as_bytes())?;
 		Ok(ErrNo::Success)
 	}
 
@@ -133,7 +136,7 @@ impl<'a> crate::Runtime<'a> {
 		environ_count: P<u32>,
 		environ_buf_size: P<u32>,
 	) -> crate::Result<ErrNo> {
-		self.memory.set_value(environ_count, 4u32)?; // sender, address, aad, value
+		self.memory.set_value(environ_count, 5u32)?; // sender, address, aad, value, rust_backtrace
 		self.memory.set_value(
 			environ_buf_size,
 			#[rustfmt::skip] (
@@ -141,6 +144,7 @@ impl<'a> crate::Runtime<'a> {
 				"\0ADDRESS=".len() + ADDR_CHARS +
 				"\0AAD=".len() + self.context.aad_str.len() +
 				"\0VALUE=".len() + self.context.value_str.len() +
+				"\0RUST_BACKTRACE=1".len() +
 				"\0".len()
 			) as u32,
 		)?;


### PR DESCRIPTION
... in the hopes of seeing backtraces when Rust-to-WASM compiled services panic.

The WASM services that run inside the oasis runtime are mostly (AFAIK even always, right now) compiled from Rust. If the Rust code panics, it will only print a stack trace if RUST_BACKTRACE=1 is present in the environment.

The Rust code cares about the environment inside the WASM interpreter; this PR attempts to set it up.

Testing: Built an `oasis-chain` image that uses this branch. Ran `oasis-chain` locally, deployed a WASM service with an intentional error, observed `oasis-chain` output. Previously, it said something like `set RUST_BACKTRACE=1 to see the trace`. Now, it says `stack backtrace:`, but no stack trace follows.

So this PR doesn't get us all the way to backtraces, but it's a step in the right direction :). Maybe we need an extra compilation flag? It's a low-priority problem.